### PR TITLE
Fix Sendgrid Authentication Method

### DIFF
--- a/CoreIdentity.API/CoreIdentity.API.csproj
+++ b/CoreIdentity.API/CoreIdentity.API.csproj
@@ -23,6 +23,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.3" />
+    <PackageReference Include="SendGrid" Version="9.21.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.5.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="5.1.2" />
   </ItemGroup>

--- a/CoreIdentity.API/Settings/EmailSettings.cs
+++ b/CoreIdentity.API/Settings/EmailSettings.cs
@@ -7,13 +7,10 @@ namespace CoreIdentity.API.Settings
 {
     public class EmailSettings
     {
-        public bool DefaultCredentials { get; set; }
         public string To { get; set; }
         public string From { get; set; }
-        public string SMTPServer { get; set; }
-        public string UserName { get; set; }
-        public string Password { get; set; }
-        public int Port { get; set; }
         public string DisplayName { get; set; }
+        public string SendGridApiKey { get; set; }
+
     }
 }

--- a/CoreIdentity.API/appsettings.Development.json
+++ b/CoreIdentity.API/appsettings.Development.json
@@ -8,14 +8,10 @@
     "ContainerName": "xxx"
   },
   "Email": {
-    "From": "xxx@xxx.xxx",
-    "To": "xxx@xxx.xxx",
-    "SMTPServer": "smtp.sendgrid.net",
-    "Port": 587,
-    "DefaultCredentials": false,
-    "UserName": "azure_xxx@azure.com",
-    "Password": "xxx",
-    "DisplayName": ""
+    "From": "xxx",
+    "To": "xxx",
+    "SendGridApiKey": "SG.xxx.xxx",
+    "DisplayName": "CoreIdentity"
   },
   "JwtSecurityToken": {
     "key": "C1CF4B7DC4C4175B6618DE4F55CA4",


### PR DESCRIPTION
This replaces the username and password authentication for sending SMTP emails with SendGrid. SendGrid require users to use their API Key (self-generated) to send emails. 